### PR TITLE
feat(design-token): design-token 패키지를 구축합니다.

### DIFF
--- a/packages/design-token/index.ts
+++ b/packages/design-token/index.ts
@@ -1,0 +1,5 @@
+import color from './src/color';
+import font from './src/font';
+import globalStyle from './src/global';
+
+export { color, font, globalStyle };

--- a/packages/design-token/package.json
+++ b/packages/design-token/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@setaday/design-token",
+  "description": "Setaday에서 사용되는 design token을 제공해요.",
+  "version": "1.0.0",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.6.2"
+  },
+  "peerDependencies": {
+    "tailwindcss": "^3.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/design-token/src/color.ts
+++ b/packages/design-token/src/color.ts
@@ -1,0 +1,25 @@
+const color = {
+  key: "#3875EC",
+  white: "#FFFFFF",
+  black: "#000000",
+
+  sub: {
+    1: "#ECF4FD",
+    2: "#DEEDFF",
+    3: "#BCDBFF",
+    4: "#8EC2FF",
+  },
+
+  gray: {
+    1: "#F8F8F8",
+    1.3: "#E7E7E7",
+    1.5: "#D4E1E7",
+    2: "#DFE3E5",
+    3: "#B3BAC0",
+    4: "#979AA0",
+    5: "#454545",
+    6: "#191919",
+  },
+};
+
+export default color;

--- a/packages/design-token/src/font.ts
+++ b/packages/design-token/src/font.ts
@@ -1,0 +1,19 @@
+const font = {
+  'head1_b_22': ['2.2rem', { lineHeight: 'auto', letterSpacing: '0px', fontWeight: '700', fontFamily: 'DM Sans'}],
+  'body1_b_18': ['1.8rem', { lineHeight: 'auto', letterSpacing: '0px', fontWeight: '700', fontFamily: 'DM Sans'}],
+  'body2_b_16': ['1.6rem', { lineHeight: 'auto', letterSpacing: '0px', fontWeight: '700', fontFamily: 'DM Sans'}],
+  'body3_m_16': ['1.6rem', { lineHeight: 'auto', letterSpacing: '0px', fontWeight: '500', fontFamily: 'DM Sans'}],
+  'body4_r_16': ['1.6rem', { lineHeight: 'auto', letterSpacing: '0px', fontWeight: '400', fontFamily: 'DM Sans'}],
+  'body5_m_14': ['1.4rem', { lineHeight: 'auto', letterSpacing: '0px', fontWeight: '500', fontFamily: 'DM Sans'}],
+  'body6_m_12': ['1.2rem', { lineHeight: 'auto', letterSpacing: '0px', fontWeight: '500', fontFamily: 'DM Sans'}],
+  'button2_sb_20': ['2rem', { lineHeight: '140%', letterSpacing: '-0.5px', fontWeight: '600', fontFamily: 'Pretendard'}],
+  'head2_sb_18': ['1.8rem', { lineHeight: '140%', letterSpacing: '-1px', fontWeight: '600', fontFamily: 'Pretendard'}],
+  'button1_sb_18': ['1.8rem', { lineHeight: '140%', letterSpacing: '-0.5px', fontWeight: '600', fontFamily: 'Pretendard'}],
+  'title1_sb_16': ['1.6rem', { lineHeight: '140%', letterSpacing: '-0.2px', fontWeight: '600', fontFamily: 'Pretendard'}],
+  'body7_m_16': ['1.6rem', { lineHeight: '140%', letterSpacing: '-1px', fontWeight: '500', fontFamily: 'Pretendard'}],
+  'caption1_m_12': ['1.2rem', { lineHeight: 'auto', letterSpacing: '-0px', fontWeight: '500', fontFamily: 'Pretendard'}],
+  'body8_m_14': ['1.4rem', { lineHeight: 'auto', letterSpacing: '-1.5px', fontWeight: '500', fontFamily: 'Pretendard'}],
+  'body9_sb_14': ['1.4rem', { lineHeight: 'auto', letterSpacing: '-2px', fontWeight: '600', fontFamily: 'Pretendard'}],
+};
+
+export default font;

--- a/packages/design-token/src/global.ts
+++ b/packages/design-token/src/global.ts
@@ -1,0 +1,17 @@
+const globalStyle = {
+  html: {
+    fontSize: "62.5%",
+    boxSizing: "border-box",
+  },
+  "*, *:before, *:after": {
+    boxSizing: "inherit",
+  },
+  body: {
+    margin: 0,
+    padding: 0,
+    WebkitFontSmoothing: "antialiased",
+    MozOsxFontSmoothing: "grayscale",
+  },
+};
+
+export default globalStyle;

--- a/packages/design-token/tsconfig.json
+++ b/packages/design-token/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,16 @@ importers:
         specifier: ^5
         version: 5.5.4
 
+  packages/design-token:
+    dependencies:
+      tailwindcss:
+        specifier: ^3.0.0
+        version: 3.4.9(ts-node@10.9.2(@types/node@22.1.0)(typescript@5.6.2))
+    devDependencies:
+      typescript:
+        specifier: ^5.6.2
+        version: 5.6.2
+
   packages/eslint-config:
     devDependencies:
       '@typescript-eslint/eslint-plugin':
@@ -5672,6 +5682,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.6.2:
+    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
 
@@ -9397,7 +9412,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.33.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
@@ -9451,7 +9466,7 @@ snapshots:
       enhanced-resolve: 5.15.0
       eslint: 8.57.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -9499,7 +9514,7 @@ snapshots:
       eslint: 9.8.0
       ignore: 5.3.1
 
-  eslint-plugin-import@2.29.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -11361,6 +11376,14 @@ snapshots:
       postcss: 8.4.41
       ts-node: 10.9.2(@types/node@22.1.0)(typescript@5.5.4)
 
+  postcss-load-config@4.0.2(postcss@8.4.41)(ts-node@10.9.2(@types/node@22.1.0)(typescript@5.6.2)):
+    dependencies:
+      lilconfig: 3.1.2
+      yaml: 2.5.0
+    optionalDependencies:
+      postcss: 8.4.41
+      ts-node: 10.9.2(@types/node@22.1.0)(typescript@5.6.2)
+
   postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.41)(yaml@2.5.0):
     dependencies:
       lilconfig: 3.1.2
@@ -12226,6 +12249,33 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
+  tailwindcss@3.4.9(ts-node@10.9.2(@types/node@22.1.0)(typescript@5.6.2)):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.2
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.6
+      lilconfig: 2.1.0
+      micromatch: 4.0.7
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.1
+      postcss: 8.4.41
+      postcss-import: 15.1.0(postcss@8.4.41)
+      postcss-js: 4.0.1(postcss@8.4.41)
+      postcss-load-config: 4.0.2(postcss@8.4.41)(ts-node@10.9.2(@types/node@22.1.0)(typescript@5.6.2))
+      postcss-nested: 6.2.0(postcss@8.4.41)
+      postcss-selector-parser: 6.1.1
+      resolve: 1.22.8
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
+
   tapable@2.2.1: {}
 
   tar@6.2.1:
@@ -12362,6 +12412,25 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.5.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
+  ts-node@10.9.2(@types/node@22.1.0)(typescript@5.6.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.1.0
+      acorn: 8.12.1
+      acorn-walk: 8.3.3
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.6.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -12529,6 +12598,8 @@ snapshots:
       possible-typed-array-names: 1.0.0
 
   typescript@5.5.4: {}
+
+  typescript@5.6.2: {}
 
   ufo@1.5.4: {}
 


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #20 

## ✅ 작업 내용

Setaday에 사용되는 design-token 패키지를 구축하고 npm에 배포했어요.
https://www.npmjs.com/package/@setaday/design-token

`color.ts`: 컬러 시스템 정의
`font.ts`: 폰트 시스템 정의
`global.ts`: 글로벌 스타일 시스템 정의

`tailwind.config.ts`에서 다음과 같이 가져다가 사용하면 됩니다!

```ts
const { color, font, globalStyle } = require('@setaday/design-token');

module.exports = {
  content: [
    // ...
  ],
  theme: {
    extend: {
      color: color,
      fontSize: font,
    },
  },
  plugins: [
    function({ addBase }) {
      addBase(globalStyle);
    },
  ],
}
```


