### PR TITLE
feat(ui): TextField 컴포넌트를 개발합니다. 

### DIFF
--- a/.changeset/tidy-birds-attack.md
+++ b/.changeset/tidy-birds-attack.md
@@ -1,0 +1,5 @@
+---
+"@setaday/ui": minor
+---
+
+Add TextField Component

--- a/packages/ui/src/TextField/TextField.stories.tsx
+++ b/packages/ui/src/TextField/TextField.stories.tsx
@@ -1,0 +1,75 @@
+import TextField from "./TextField";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "Components/TextField",
+  component: TextField,
+  parameters: {
+    componentSubtitle: "TextField는 사용자에게 입력창을 제공하는 컴포넌트입니다.",
+  },
+  argTypes: {
+    isError: {
+      description: "입력값의 오류 여부를 설정합니다.",
+      control: "select",
+    },
+    inputSize: {
+      description: "입력창의 크기를 설정합니다.",
+      control: "select",
+    },
+  },
+} as Meta<typeof TextField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const DesktopDefault: Story = {
+  args: {
+    inputSize: "desktop",
+    maxLength: 10,
+    value: "약속 생성하기",
+  },
+};
+
+export const DesktopError: Story = {
+  args: {
+    isError: true,
+    inputSize: "desktop",
+    maxLength: 10,
+    value: "약속 생성하기",
+  },
+};
+
+export const DesktopLargeDefault: Story = {
+  args: {
+    inputSize: "desktop_lg",
+    maxLength: 10,
+    value: "약속 생성하기",
+  },
+};
+
+export const DesktopLargeError: Story = {
+  args: {
+    isError: true,
+    inputSize: "desktop_lg",
+    maxLength: 10,
+    value: "약속 생성하기",
+  },
+};
+
+export const MobileDefault: Story = {
+  args: {
+    inputSize: "mobile",
+    maxLength: 10,
+    value: "약속 생성하기",
+  },
+};
+
+export const MobileError: Story = {
+  args: {
+    isError: true,
+    inputSize: "mobile",
+    maxLength: 10,
+    value: "약속 생성하기",
+  },
+};

--- a/packages/ui/src/TextField/TextField.styles.ts
+++ b/packages/ui/src/TextField/TextField.styles.ts
@@ -1,0 +1,17 @@
+import { cva } from "class-variance-authority";
+
+export const textFieldVariants = cva(
+  `rounded-[0.8rem] bg-gray-1 flex justify-between items-center px-[2rem] gap-[1rem]`,
+  {
+    variants: {
+      isError: {
+        true: "shadow-[inset_0_0_0_1px_red]",
+      },
+      inputSize: {
+        desktop: "w-[33.5rem] h-[5.7rem]",
+        desktop_lg: "w-[51rem] h-[6.1rem]",
+        mobile: "w-[33.5rem] h-[4.8rem]",
+      },
+    },
+  },
+);

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -1,0 +1,27 @@
+import { textFieldVariants } from "./TextField.styles";
+import { cn } from "@setaday/util";
+import { type InputHTMLAttributes } from "react";
+
+interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  isError?: boolean;
+  maxLength: number;
+  inputSize: "desktop" | "desktop_lg" | "mobile";
+  value: string;
+}
+
+const TextField = ({ isError = false, value, maxLength, inputSize, ...inputProps }: TextFieldProps) => {
+  return (
+    <div className={cn(textFieldVariants({ isError, inputSize }))}>
+      <input
+        {...inputProps}
+        value={value}
+        className="bg-gray-1 text-gray-6 text-body7_m_16 w-full focus:outline-none"
+      />
+      <span className="text-gray-2 text-body6_m_12">
+        {value.length}/{maxLength}
+      </span>
+    </div>
+  );
+};
+
+export default TextField;

--- a/packages/ui/src/TextField/index.ts
+++ b/packages/ui/src/TextField/index.ts
@@ -1,0 +1,1 @@
+export { default as TextField } from "./TextField";


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #34 

## ✅ 작업 내용

TextField 컴포넌트를 개발했어요. UI는 `ui` 패키지의 Storybook에서 확인할 수 있어요.

값이 변경될 때마다 유효성을 검사하고 이에 따른 즉각적인 UI의 변화가 필요하므로 제어 컴포넌트로 설계했어요. 따라서 `value` prop으로 input 값을 관리하는 state를 넘겨주고, `onChange` prop으로 state를 변경시켜주는 로직을 담은 함수를 넘겨주어야 해요.

인터페이스는 다음과 같아요.

```ts
interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
  isError?: boolean;
  maxLength: number;
  inputSize: "desktop" | "desktop_lg" | "mobile";
  value: string;
}
```

> isError: 에러 발생 여부. true일 경우 붉은 테두리가 생성돼요.
> maxLength: 허용하는 입력값 최대 길이에요.
>  inputSize: TextField의 크기에요. 모바일 / 데스크탑 / 데스크탑 Large(이름과 비밀번호 입력 시 사용돼요.)
> value: TextField의 입력값을 관리하는 state에요.
