### PR TITLE
feat(mobile): 시간 선택 View Layout을 구현합니다.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,17 @@
     {
       "mode": "auto"
     }
-  ]
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "never",
+    // stylelint 자동 수정
+    "source.fixAll.stylelint": "explicit",
+    // eslint 자동 수정
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.tslint": "never",
+    // 사용하지 않은 import 삭제
+    "source.organizeImports": "explicit"
+  },
+
+  "stylelint.validate": ["css", "scss", "postcss", "typescript", "typescriptreact"]
 }

--- a/apps/mobile/app/select-date/layout.tsx
+++ b/apps/mobile/app/select-date/layout.tsx
@@ -1,0 +1,14 @@
+import SelectDateHeader from "../../components/select-date/SelectDateHeader";
+
+export default function layout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+      <SelectDateHeader />
+      <div className="px-[2rem]">{children}</div>
+    </>
+  );
+}

--- a/apps/mobile/app/select-date/layout.tsx
+++ b/apps/mobile/app/select-date/layout.tsx
@@ -8,7 +8,7 @@ export default function layout({
   return (
     <>
       <SelectDateHeader />
-      <div className="px-[2rem]">{children}</div>
+      <div className="p-[2rem]">{children}</div>
     </>
   );
 }

--- a/apps/mobile/app/select-date/page.tsx
+++ b/apps/mobile/app/select-date/page.tsx
@@ -1,0 +1,3 @@
+export default function page() {
+  return <div>hi</div>;
+}

--- a/apps/mobile/components/select-date/SelectDateHeader.tsx
+++ b/apps/mobile/components/select-date/SelectDateHeader.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import { MobileIconArrowLeftBlack } from "@setaday/icon";
+import { useRouter } from "next/navigation";
 
 function SelectDateHeader() {
+  const router = useRouter();
+  const clickArrowBtn = () => {
+    router.back();
+  };
   return (
     <header className="border-gray-1 flex h-[5.2rem] w-[100dvw] items-center justify-between border-b-[1px] px-[0.9rem]">
-      <button onClick={() => window.history.back()}>
+      <button onClick={clickArrowBtn}>
         <MobileIconArrowLeftBlack />
       </button>
 

--- a/apps/mobile/components/select-date/SelectDateHeader.tsx
+++ b/apps/mobile/components/select-date/SelectDateHeader.tsx
@@ -1,9 +1,11 @@
+"use client";
+
 import { MobileIconArrowLeftBlack } from "@setaday/icon";
 
 function SelectDateHeader() {
   return (
     <header className="border-gray-1 flex h-[5.2rem] w-[100dvw] items-center justify-between border-b-[1px] px-[0.9rem]">
-      <button>
+      <button onClick={() => window.history.back()}>
         <MobileIconArrowLeftBlack />
       </button>
 

--- a/apps/mobile/components/select-date/SelectDateHeader.tsx
+++ b/apps/mobile/components/select-date/SelectDateHeader.tsx
@@ -1,0 +1,17 @@
+import { MobileIconArrowLeftBlack } from "@setaday/icon";
+
+function SelectDateHeader() {
+  return (
+    <header className="border-gray-1 flex h-[5.2rem] w-[100dvw] items-center justify-between border-b-[1px] px-[0.9rem]">
+      <button>
+        <MobileIconArrowLeftBlack />
+      </button>
+
+      <h2 className="font-body3_m_16 text-gray-6">날짜 선택</h2>
+
+      <div className="h-[3.2rem] w-[3.2rem]"></div>
+    </header>
+  );
+}
+
+export default SelectDateHeader;

--- a/apps/mobile/styles/globals.css
+++ b/apps/mobile/styles/globals.css
@@ -148,6 +148,8 @@
     @apply m-0 mx-auto min-h-[100dvh] w-[100vw] max-w-[43rem];
     -ms-overflow-style: none;
     scrollbar-width: none;
+    margin: 0;
+    padding: 0;
   }
 
   #root::-webkit-scrollbar {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #58 

## ✅ 작업 내용
### 1️⃣ 마진, 패딩 초기화
기존 세팅에서는 페이지 전체에 일괄적으로 적용되는 마진과 패딩 값을 0으로 초기화하지 않아서, `width: 100dvw` 같은 레이아웃을 적용했을 때 원하는대로 동작하지 않는 것을 확인했어요. 예를 들어 헤더 너비는 화면 너비에 맞게 꽉 차야하는데, 페이지에 적용되어있는 기본 세팅때문에 `width: 100dvw`를 적용해도 헤더가 화면의 왼쪽 끝에서 오른쪽 끝으로 꽉 차지 않더라구요. (왼쪽 끝이 아닌 중간 지점부터 시작함) 이러한 문제들을 방지하기 위해 스타일 전체에 마진과 패딩을 0으로 초기화해뒀습니다 !

<br />

### 2️⃣ 날짜 선택 View 헤더 구현
단순 레이아웃 구현이기 때문에, 크게 중요한 내용은 없어요 ! 
다만, 넥제에서는 뒤로가기 기능을 구현할 때 `window.history.back()`을 활용하거나 `next/navigate`의 `useRouter()`를 사용한다고 하더라구요. 둘 중에 어떤 방식으로 구현하는게 좋을지 찾아보니 아래와 같은 차이점이 있었어요.
- **window.history.back()**
  - 브라우저 기본 히스토리 API
  - 클라이언트 사이드에서만 동작
  - 넥제와 독립적으로 동작
  
- **router.back()**
   - 넥제 라우팅 시스템 내부에서 동작
   - 서버 사이드에서도 동작
   - 넥제의 기능들과 통합하여 사용 가능

이러한 차이점을 두고 봤을 때, 클라이언트 사이드에서만 동작하는 `window.history.back()`보다는 서버 사이드에서도 동작하는 `router.back()`이 적합하다고 판단하여 이를 활용한 코드로 구현했어요. 넥제가 익숙하지 않다보니 제 코드에 대한 100% 확신은 없네요 .. ^_ㅠ 
 다른 의견있으면 마구 피드백해주세요

<br />

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/c1010704-c210-4c3f-88bc-c792e5bab172


