### PR TITLE
bugfix: lint-staged command 오류를 수정합니다.

### DIFF
--- a/apps/mobile/app/select-time/page.tsx
+++ b/apps/mobile/app/select-time/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import SelectTimeOptionSelect from "../../components/SelectTimeOptionSelect";
-import { SelectModeType, SelectTimeOptionType } from "./type";
 import { MobileIconDraw, MobileIconDrawChoose, MobileIconErase, MobileIconEraseChoose } from "@setaday/icon";
 import { useState } from "react";
+import SelectTimeOptionSelect from "../../components/SelectTimeOptionSelect";
+import type { SelectModeType, SelectTimeOptionType } from "./type";
 
 export default function Page() {
   const [selectTimeOption, setSelectTimeOption] = useState<SelectTimeOptionType>("myTime");
@@ -38,10 +38,10 @@ export default function Page() {
           <SelectTimeOptionSelect selectTimeOption={selectTimeOption} handleSelectOption={handleSelectOption} />
           {selectTimeOption === "myTime" && (
             <div className="flex h-[3.4rem] items-center gap-[0.6rem]">
-              <button onClick={handleClickWriteButton}>
+              <button type="button" onClick={handleClickWriteButton}>
                 {selectMode === "write" ? <MobileIconDrawChoose /> : <MobileIconDraw />}
               </button>
-              <button onClick={handleClickEraseButton}>
+              <button type="button" onClick={handleClickEraseButton}>
                 {selectMode === "erase" ? <MobileIconEraseChoose /> : <MobileIconErase />}
               </button>
             </div>

--- a/apps/mobile/components/SelectTimeHeader.tsx
+++ b/apps/mobile/components/SelectTimeHeader.tsx
@@ -2,7 +2,6 @@
 
 import { MobileIconDonate, MobileIconSharing, MobileIconTeam, MobileLogo } from "@setaday/icon";
 import Link from "next/link";
-import React from "react";
 
 function SelectTimeHeader() {
   const handleClickDonateButton = () => {
@@ -23,13 +22,13 @@ function SelectTimeHeader() {
         <MobileLogo />
       </Link>
       <div className="flex gap-[0.8rem]">
-        <button onClick={handleClickDonateButton}>
+        <button type="button" onClick={handleClickDonateButton}>
           <MobileIconDonate />
         </button>
-        <button onClick={handleClickTeamButton}>
+        <button type="button" onClick={handleClickTeamButton}>
           <MobileIconTeam />
         </button>
-        <button onClick={handleClickSharingButton}>
+        <button type="button" onClick={handleClickSharingButton}>
           <MobileIconSharing />
         </button>
       </div>

--- a/biome.json
+++ b/biome.json
@@ -1,25 +1,25 @@
 {
-    "$schema": "https://biomejs.dev/schemas/1.4.1/schema.json",
-    "organizeImports": {
-      "enabled": true
-    },
-    "linter": {
-      "enabled": true,
-      "rules": {
-        "recommended": true
-      }
-    },
+  "$schema": "https://biomejs.dev/schemas/1.4.1/schema.json",
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120
+  },
+  "javascript": {
     "formatter": {
-      "enabled": true,
-      "indentStyle": "space",
-      "indentWidth": 2,
-      "lineWidth": 120
-    },
-    "javascript": {
-      "formatter": {
-        "quoteStyle": "double",
-        "trailingComma": "es5",
-        "semicolons": "always"
-      }
+      "quoteStyle": "double",
+      "trailingCommas": "es5",
+      "semicolons": "always"
     }
   }
+}

--- a/package.json
+++ b/package.json
@@ -11,11 +11,10 @@
     "version-packages": "changeset version",
     "release": "turbo run build && changeset publish",
     "format": "biome format --write .",
-    "lint": "biome lint .",
-    "check": "biome check --apply ."
+    "lint": "biome lint ."
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": "biome check --apply --format"
+    "*.{js,jsx,ts,tsx}": "biome check --no-errors-on-unmatched"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #70 

## ✅ 작업 내용

lint-staged command 오류를 수정했어요.

Biome 공식문서를 다시 정독했는데, check command에 `--format`이라는 option은 존재하지 않았어요. 심지어 자동적용 옵션도 `--apply`가 아니라 `--write`였어요... 

저희 논의 후에 자동적용은 끄기로 결정했으므로, --write 옵션은 추가하지 않았어요.
대신 `--no-errors-on-unmatched` 옵션을 추가해주었는데, glob 패턴으로 *.{js,jsx,ts,tsx} 파일들을 검사할 때, 해당 패턴과 일치하지 않는 파일이 있더라도 에러로 처리하지 않고 건너뛰도록 설정하기 위해 추가해줬어요.

추가적으로 제가 이전에 작성한 모바일 뷰 코드들에서 lint 오류가 나는 부분을 수정했어요.
