### PR TITLE
bugfix(ui): UI 패키지 스타일 주입 오류를 수정합니다.

### DIFF
--- a/.changeset/sour-clocks-smoke.md
+++ b/.changeset/sour-clocks-smoke.md
@@ -1,0 +1,5 @@
+---
+"@setaday/ui": patch
+---
+
+fix style injection error

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -1,3 +1,4 @@
+import "./dist/styles.css";
 import "./styles/globals.css";
 
 export { default as Button } from "./src/Button/Button";

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -17,7 +17,7 @@ const TextField = ({ isError = false, value, maxLength, inputSize, ...inputProps
         value={value}
         className="bg-gray-1 text-gray-6 font-body7_m_16 w-full focus:outline-none"
       />
-      <span className="text-gray-2 text-body6_m_12">
+      <span className="text-gray-2 font-body6_m_12">
         {value.length}/{maxLength}
       </span>
     </div>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #66 

- Related PR #81 

## ✅ 작업 내용

새벽부터 이어진 대공사였습니다.
PR #81과 해당 PR에서 작업을 진행했어요.

먼저 ui 패키지에서 세팅한 tailwind config와 프로덕트 패키지의 tailwind config간 sink를 맞춰주었어요.
그리고 기존에 ui 패키지에 적용했던 font 적용 방식을 프로덕트 패키지에서 적용한 방식으로 일원화시켰어요.

ui 패키지 빌드 후 `pnpm link --global`로 symlink를 만들고 import해서 테스트를 해봤을 때, CSS가 정상적으로 적용되지 않은 상태로 렌더링되었어요. 하지만 개발자 도구로 element의 class를 보았을 때 의도한 대로 class가 잘 적용이 되는 것을 확인했어요.

tailwind쪽에서 문제가 발생한 것이라고 확신을 하게 되었고, tailwind config에서 `"./node_modules/@setaday/ui/**/*.{js,ts,jsx,tsx}"` 이렇게 node_modules 내부에 있는 패키지까지 content에 포함시켰더니 정상적으로 스타일이 적용되었어요. 하지만 node_modules에 의존적인 config 설정은 좋은 방향이 아니라는 생각이 들었어요. 이 문제는 디자인 시스템 레벨에서 해결이 필요한 문제라고 생각했어요.

먼저 tsup config 파일에 css loader가 별도로 설정이 되어있지 않았어요. 그래서 tsup에 loader를 추가할까 하다가, tailwind와 네이티브하게 동작하는 postcss를 사용하여 별도로 빌드하는 게 여러 측면에서 이점을 가질 것이라는 생각을 했어요. 그래서 ui 패키지 build script에 다음과 같이 postcss가 CSS 파일을 빌드하도록 command를 추가해주었어요.

```js
  "scripts": {
    ...
    "build": "pnpm clean && tsup && postcss styles/globals.css -o dist/styles.css",
    ...
  },
```

그래서 ui 패키지 build entrypoint에서 CSS 빌드파일을 import하는 구문을 추가해주어 스타일이 컴포넌트에 주입된 채로 import되도록 설정해주었어요. 이제 프로덕트에서 디자인 시스템 컴포넌트를 import하면 정상적으로 스타일이 주입된 채로 렌더링돼요.
