### PR TITLE
feat(ui): TextField에 maxLength Error 처리 로직을 추가합니다.

### DIFF
--- a/.changeset/brave-zebras-cross.md
+++ b/.changeset/brave-zebras-cross.md
@@ -1,0 +1,5 @@
+---
+"@setaday/ui": minor
+---
+
+Add maxlength error handling logic in TextField

--- a/packages/ui/src/TextField/TextField.styles.ts
+++ b/packages/ui/src/TextField/TextField.styles.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const textFieldVariants = cva(
-  `rounded-[0.8rem] bg-gray-1 flex justify-between items-center px-[2rem] gap-[1rem]`,
+  "rounded-[0.8rem] mb-[0.4rem] bg-gray-1 flex justify-between items-center px-[2rem] gap-[1rem]",
   {
     variants: {
       isError: {
@@ -10,8 +10,16 @@ export const textFieldVariants = cva(
       inputSize: {
         desktop: "w-[33.5rem] h-[5.7rem]",
         desktop_lg: "w-[51rem] h-[6.1rem]",
-        mobile: "w-[33.5rem] h-[4.8rem]",
+        mobile: "w-[100%] h-[4.8rem]",
       },
     },
-  },
+  }
 );
+
+export const textCountVariants = cva("", {
+  variants: {
+    isError: {
+      true: "text-red-100",
+    },
+  },
+});

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -1,26 +1,52 @@
 import { cn } from "@setaday/util";
 import type { InputHTMLAttributes } from "react";
-import { textFieldVariants } from "./TextField.styles";
+import { textCountVariants, textFieldVariants } from "./TextField.styles";
 
 interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   isError?: boolean;
+  errorMessage?: string;
   maxLength: number;
   inputSize: "desktop" | "desktop_lg" | "mobile";
   value: string;
 }
 
-const TextField = ({ isError = false, value, maxLength, inputSize, ...inputProps }: TextFieldProps) => {
+const TextField = ({ isError = false, errorMessage, value, maxLength, inputSize, ...inputProps }: TextFieldProps) => {
   return (
-    <div className={cn(textFieldVariants({ isError, inputSize }))}>
-      <input
-        {...inputProps}
-        value={value}
-        className="bg-gray-1 text-gray-6 font-body7_m_16 w-full focus:outline-none"
-      />
-      <span className="text-gray-2 font-body6_m_12">
-        {value.length}/{maxLength}
-      </span>
-    </div>
+    <>
+      <div
+        className={cn(
+          textFieldVariants({
+            isError: isError || value.length > maxLength,
+            inputSize,
+          })
+        )}
+      >
+        <input
+          {...inputProps}
+          value={value}
+          className="bg-gray-1 text-gray-6 font-body7_m_16 w-full focus:outline-none"
+        />
+        <span className="text-gray-2 font-body6_m_12">
+          <span
+            className={cn(
+              textCountVariants({
+                isError: isError || value.length > maxLength,
+              })
+            )}
+          >
+            {value.length}
+          </span>
+          /{maxLength}
+        </span>
+      </div>
+      <div className="h-[1.45rem]">
+        {value.length > maxLength || (isError && errorMessage) ? (
+          <span className="text-red-100 font-caption1_m_12">
+            {value.length > maxLength ? `${maxLength}자가 초과되었어요` : errorMessage}
+          </span>
+        ) : null}
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #91 

## ✅ 작업 내용

처음 TextField 컴포넌트를 설계할 때 순수 컴포넌트로 설계해서 모든 에러처리 로직을 외부에서 주입하도록 설계했었어요.
그런데 maxLength를 초과하는 경우는 너무나도 분명한 에러케이스였고, 분명한 에러케이스들도 외부에서 매번 핸들링 로직을 만들어서 주입해야 하는 게 비효율적이고 불편할 것이라는 생각이 들었어요.

그래서 maxLength를 초과하는 에러는 컴포넌트 레벨에서 처리하도록 설계했어요. 이제  onChange 핸들러에 초과 검사 로직을 포함하지 않아도 됩니다!! 또 컴포넌트 레벨에서 지원했으면 하는 추가적인 Default 에러 핸들링 로직이 있다면 제안주셔도 좋아요.

또 `errorMessage`라는 optional string 타입 인터페이스를 추가했어요. 에러 발생시 경고 메시지를 `errorMessage` prop으로 넘겨주면 isError가 true인 상태에서 TextField 하단에 렌더링돼요. 참고로 maxLength를 초과하는 에러에 대해서는 에러 메시지도 컴포넌트 레벨에서 처리하도록 했으므로 prop으로 넘겨주지 않아도 돼요.

++ red color가 디자인 시스템에 나중에 추가되어서 `color` 패키지에 아직 반영되어있지 않아요. 그래서 Tailwind에서 자체 제공하는 임시 red 색상으로 적용해뒀는데 다음 issue로 파서 `color` 패키지에 추가하고 ui 컴포넌트에도 반영해둘게요!

![image](https://github.com/user-attachments/assets/fab3ac49-dd5d-427d-afba-2375c4d0259d)
