### PR TITLE
fix(ui): Button inputSize prop이 mobile일 시 width를 100%로 수정합니다.

### DIFF
--- a/.changeset/swift-kangaroos-unite.md
+++ b/.changeset/swift-kangaroos-unite.md
@@ -1,0 +1,5 @@
+---
+"@setaday/ui": patch
+---
+
+set mobile default button width to 100%

--- a/packages/ui/src/Button/Button.styles.ts
+++ b/packages/ui/src/Button/Button.styles.ts
@@ -10,7 +10,7 @@ export const buttonVariants = cva("text-white rounded-[0.8rem]", {
     size: {
       default: "",
       desktop: "w-[22.6rem] h-[5.7rem]",
-      mobile: "w-[33.5rem] h-[5.6rem]",
+      mobile: "w-[100%] h-[5.6rem]",
       desktop_donate: "w-[33.5rem] h-[5.6rem]",
       mobile_donate: "w-[20.2rem] h-[3.9rem]",
     },


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #107 

## ✅ 작업 내용

모바일 기기별 뷰포트 너비에 동적으로 대응하기 위해 Button 컴포넌트 inputSize prop이 mobile일 시 width를 100%로 수정했어요.
