### PR TITLE
fix(mobile): 모바일로 확인했을 때 ui가 깨지는 이슈를 해결합니다.

### DIFF
--- a/apps/mobile/app/select-date/page.tsx
+++ b/apps/mobile/app/select-date/page.tsx
@@ -10,7 +10,8 @@ export default function page() {
 
   const [planName, setPlanName] = useState("");
   const [isDateSelected, setIsDateSelected] = useState(false);
-  const isActiveBtn = planName.length > 0 && isDateSelected;
+  const isRightName = planName.length > 0 && planName.length < 17;
+  const isActiveBtn = isRightName && isDateSelected;
 
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.currentTarget;

--- a/apps/mobile/app/select-date/page.tsx
+++ b/apps/mobile/app/select-date/page.tsx
@@ -34,7 +34,7 @@ export default function page() {
 
       <SelectDateCalendar handleSelectDate={handleSelectDate} />
 
-      <Button color={isActiveBtn ? "default" : "disabled"} font="default" size="mobile">
+      <Button color={isActiveBtn ? "default" : "disabled"} font="default" size="mobile" disabled={!isActiveBtn}>
         다음으로
       </Button>
     </div>

--- a/apps/mobile/app/select-date/page.tsx
+++ b/apps/mobile/app/select-date/page.tsx
@@ -9,15 +9,16 @@ export default function page() {
   const MAX_LENGTH = 16;
 
   const [planName, setPlanName] = useState("");
-  const [isDisabledNextBtn, setIsDisabledNextBtn] = useState(true);
+  const [isDateSelected, setIsDateSelected] = useState(false);
+  const isActiveBtn = planName.length > 0 && isDateSelected;
 
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.currentTarget;
     setPlanName(value);
   };
 
-  const handleDisabledNextBtn = (isDisabled: boolean) => {
-    setIsDisabledNextBtn(isDisabled);
+  const handlSelecteDate = (isSelected: boolean) => {
+    setIsDateSelected(isSelected);
   };
 
   return (
@@ -30,10 +31,10 @@ export default function page() {
           maxLength={MAX_LENGTH}
           onChange={handleChangeInput}
         />
-        <SelectDateCalendar handleDisabledNextBtn={handleDisabledNextBtn} />
+        <SelectDateCalendar handlSelecteDate={handlSelecteDate} />
       </div>
 
-      <Button color={isDisabledNextBtn ? "cancel" : "default"} font="default" size="mobile">
+      <Button color={isActiveBtn ? "default" : "cancel"} font="default" size="mobile">
         다음으로
       </Button>
     </div>

--- a/apps/mobile/app/select-date/page.tsx
+++ b/apps/mobile/app/select-date/page.tsx
@@ -34,7 +34,7 @@ export default function page() {
 
       <SelectDateCalendar handlSelecteDate={handlSelecteDate} />
 
-      <Button color={isActiveBtn ? "default" : "cancel"} font="default" size="mobile">
+      <Button color={isActiveBtn ? "default" : "disabled"} font="default" size="mobile">
         다음으로
       </Button>
     </div>

--- a/apps/mobile/app/select-date/page.tsx
+++ b/apps/mobile/app/select-date/page.tsx
@@ -18,7 +18,7 @@ export default function page() {
     setPlanName(value);
   };
 
-  const handlSelecteDate = (isSelected: boolean) => {
+  const handleSelectDate = (isSelected: boolean) => {
     setIsDateSelected(isSelected);
   };
 
@@ -32,7 +32,7 @@ export default function page() {
         onChange={handleChangeInput}
       />
 
-      <SelectDateCalendar handlSelecteDate={handlSelecteDate} />
+      <SelectDateCalendar handleSelectDate={handleSelectDate} />
 
       <Button color={isActiveBtn ? "default" : "disabled"} font="default" size="mobile">
         다음으로

--- a/apps/mobile/app/select-date/page.tsx
+++ b/apps/mobile/app/select-date/page.tsx
@@ -23,16 +23,15 @@ export default function page() {
 
   return (
     <div className="flex flex-col justify-between h-[calc(100dvh-11.2rem)]">
-      <div>
-        <TextField
-          inputSize="mobile"
-          placeholder={PLACE_HOLDER}
-          value={planName}
-          maxLength={MAX_LENGTH}
-          onChange={handleChangeInput}
-        />
-        <SelectDateCalendar handlSelecteDate={handlSelecteDate} />
-      </div>
+      <TextField
+        inputSize="mobile"
+        placeholder={PLACE_HOLDER}
+        value={planName}
+        maxLength={MAX_LENGTH}
+        onChange={handleChangeInput}
+      />
+
+      <SelectDateCalendar handlSelecteDate={handlSelecteDate} />
 
       <Button color={isActiveBtn ? "default" : "cancel"} font="default" size="mobile">
         다음으로

--- a/apps/mobile/components/select-date/SelectDateCalendar.tsx
+++ b/apps/mobile/components/select-date/SelectDateCalendar.tsx
@@ -6,9 +6,9 @@ import { DAY, MONTH_NAMES } from "../../contants/calendarConst";
 import { getCalendarDate } from "../../utils/getCalendarDate";
 
 function SelectDateCalendar({
-  handleDisabledNextBtn,
+  handlSelecteDate,
 }: {
-  handleDisabledNextBtn: (isDisabled: boolean) => void;
+  handlSelecteDate: (isSelected: boolean) => void;
 }) {
   const [year, setYear] = useState(new Date().getFullYear());
   const [month, setMonth] = useState(new Date().getMonth() + 1);
@@ -173,17 +173,11 @@ function SelectDateCalendar({
       ];
 
       setSelectedDate(updatedDate);
-
-      if (updatedDate.length === 0) handleDisabledNextBtn(true);
-      else {
-        if (selectedDateNum.current < 14) handleDisabledNextBtn(false);
-      }
+      handlSelecteDate(false);
     } else {
       const lastDate = selectedDate[selectedDate.length - 1];
       const isStartDateNull = lastDate && lastDate.startDate === 0 && lastDate.endDate !== 0;
       const isEndDateNull = lastDate && lastDate.startDate !== 0 && lastDate.endDate === 0;
-
-      handleDisabledNextBtn(false);
 
       // 선택된 날짜가 없는 경우
       if (selectedDate.length === 0) {
@@ -197,6 +191,7 @@ function SelectDateCalendar({
             endDate: 0,
           },
         ]);
+        handlSelecteDate(false);
       }
 
       // 시작 날짜와 끝나는 날짜 중 하나가 선택되어 있는 경우
@@ -217,9 +212,10 @@ function SelectDateCalendar({
             month: startMonth,
             date: startDate,
           });
+          handlSelecteDate(true);
           if (selectedDateNum.current >= 14) {
             alert("14일 넘음");
-            handleDisabledNextBtn(true);
+            handlSelecteDate(false);
           }
         }
 
@@ -236,9 +232,10 @@ function SelectDateCalendar({
             month: endMonth,
             date: endDate,
           });
+          handlSelecteDate(true);
           if (selectedDateNum.current >= 14) {
             alert("14일 넘음");
-            handleDisabledNextBtn(true);
+            handlSelecteDate(false);
           }
         }
       }
@@ -256,6 +253,7 @@ function SelectDateCalendar({
             endDate: 0,
           },
         ]);
+        handlSelecteDate(false);
       }
     }
   };

--- a/apps/mobile/components/select-date/SelectDateCalendar.tsx
+++ b/apps/mobile/components/select-date/SelectDateCalendar.tsx
@@ -259,7 +259,7 @@ function SelectDateCalendar({
   };
 
   return (
-    <article className="flex flex-col mt-[5.6rem]">
+    <article className="flex flex-col h-[38.3rem] mb-[2rem]">
       <header className="flex items-center justify-center mb-[2.2rem]">
         <button type="button" onClick={() => handleClickArrow("left")}>
           <MobileIconArrowLeftGray />

--- a/apps/mobile/components/select-date/SelectDateCalendar.tsx
+++ b/apps/mobile/components/select-date/SelectDateCalendar.tsx
@@ -6,9 +6,9 @@ import { DAY, MONTH_NAMES } from "../../contants/calendarConst";
 import { getCalendarDate } from "../../utils/getCalendarDate";
 
 function SelectDateCalendar({
-  handlSelecteDate,
+  handleSelectDate,
 }: {
-  handlSelecteDate: (isSelected: boolean) => void;
+  handleSelectDate: (isSelected: boolean) => void;
 }) {
   const [year, setYear] = useState(new Date().getFullYear());
   const [month, setMonth] = useState(new Date().getMonth() + 1);
@@ -173,7 +173,7 @@ function SelectDateCalendar({
       ];
 
       setSelectedDate(updatedDate);
-      handlSelecteDate(false);
+      handleSelectDate(false);
     } else {
       const lastDate = selectedDate[selectedDate.length - 1];
       const isStartDateNull = lastDate && lastDate.startDate === 0 && lastDate.endDate !== 0;
@@ -191,7 +191,7 @@ function SelectDateCalendar({
             endDate: 0,
           },
         ]);
-        handlSelecteDate(false);
+        handleSelectDate(false);
       }
 
       // 시작 날짜와 끝나는 날짜 중 하나가 선택되어 있는 경우
@@ -212,10 +212,10 @@ function SelectDateCalendar({
             month: startMonth,
             date: startDate,
           });
-          handlSelecteDate(true);
+          handleSelectDate(true);
           if (selectedDateNum.current >= 14) {
             alert("14일 넘음");
-            handlSelecteDate(false);
+            handleSelectDate(false);
           }
         }
 
@@ -232,10 +232,10 @@ function SelectDateCalendar({
             month: endMonth,
             date: endDate,
           });
-          handlSelecteDate(true);
+          handleSelectDate(true);
           if (selectedDateNum.current >= 14) {
             alert("14일 넘음");
-            handlSelecteDate(false);
+            handleSelectDate(false);
           }
         }
       }
@@ -253,7 +253,7 @@ function SelectDateCalendar({
             endDate: 0,
           },
         ]);
-        handlSelecteDate(false);
+        handleSelectDate(false);
       }
     }
   };

--- a/apps/mobile/components/select-date/SelectDateCalendar.tsx
+++ b/apps/mobile/components/select-date/SelectDateCalendar.tsx
@@ -214,6 +214,7 @@ function SelectDateCalendar({
           });
           handleSelectDate(true);
           if (selectedDateNum.current >= 14) {
+            // 선택한 날짜가 14일을 넘었을 때 동작하는 플로우 추가 시 삭제 예정
             alert("14일 넘음");
             handleSelectDate(false);
           }
@@ -234,6 +235,7 @@ function SelectDateCalendar({
           });
           handleSelectDate(true);
           if (selectedDateNum.current >= 14) {
+            // 선택한 날짜가 14일을 넘었을 때 동작하는 플로우 추가 시 삭제 예정
             alert("14일 넘음");
             handleSelectDate(false);
           }

--- a/apps/mobile/components/select-date/SelectDateCalendar.tsx
+++ b/apps/mobile/components/select-date/SelectDateCalendar.tsx
@@ -339,7 +339,7 @@ function SelectDateCalendar({
                   {((isRightSelection && isClickedNum) || isInRange) && (
                     <span
                       className={`absolute top-0 ${isStartDate ? "right-0" : "left-0"} ${
-                        isClickedNum ? "w-[2.45rem]" : "w-[4.9rem]"
+                        isClickedNum ? "w-[2.45rem]" : "w-[100%]"
                       }  h-[3.6rem] bg-sub-1`}
                     />
                   )}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #117 

## ✅ 작업 내용

- [x] 날짜 선택 시, 선택된 날짜의 배경이 이어지게 수정
- [x] 하단 버튼 활성화 조건 수정
- [x] 달력 최대 높이 고정

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/d88fe477-718f-4168-a009-b7c27a2df4be

https://github.com/user-attachments/assets/30fd8a89-f321-4f79-a042-132b038f9aec


## 📌 이슈 사항
1. 날짜 선택 시, 선택된 날짜의 배경이 이어지게 수정
노트북에서 모바일 모드로 확인했을때는 날짜를 선택했을 때 배경이 기존에 의도한대로 잘 이어졌는데, 실제 모바일로 접속해서 확인하니 배경이 자연스럽게 이어지지 않고 중간에 끊기는 이슈가 있었어요. 배경 너비를 특정 값으로 지정해줬던 기존 코드를 w-[100%]로 수정해서 이슈를 해결했어요.

2. 하단 버튼 활성화 조건 수정
원래 기획대로라면 약속 제목이 작성된 상태에서 유효한 날짜선택이 있을 때 하단 버튼이 활성화 되어야 했어요. 하지만 기존 코드로 실행을 시켜봤을 때 활성화 조건이 의도와 다르게 동작해서 이 부분도 수정했어요. 약속 제목의 길이가 0보다 크고 17보다 작은 경우 && 날짜 선택이 유효한 경우에만 버튼을 활성화시켜 해당 페이지가 안정적으로 동작하도록 수정했어요.

3. 달력 최대 높이 고정
경우의 수를 따져보면 한 달은 최소 4주에서 6주로 구성되는데, 달력 높이를 고정하지 않았더니 한 달을 구성하는 주의 수가 달라질 때마다 달력 시작 위치가 달라졌어요. 사용자가 연속으로 화살표를 클릭하는 상황을 생각했을 때, 화살표의 높이가 계속 달라지면 UX에 좋지 않고 서비스 UI가 어색하게 느껴진다고 생각했어요. 이를 해결하기 위해 6주로 구성된 달력의 높이를 모든 달력의 높이로 잡아 어떠한 경우에도 달력의 시작 위치가 달리지지 않도록 구현했어요.