### PR TITLE
feat(mobile): 날짜 선택 시, 지난 날짜를 선택할 수 없도록 제한합니다.

### DIFF
--- a/apps/mobile/components/select-date/SelectDateCalendar.tsx
+++ b/apps/mobile/components/select-date/SelectDateCalendar.tsx
@@ -287,11 +287,11 @@ function SelectDateCalendar({ selectedDateNum, selectedDate, handleSelectDate }:
               const isRightSelection = !!(matchedObj && matchedObj.endDate > 0 && matchedObj.startDate > 0);
 
               return (
-                // biome-ignore lint/a11y/useKeyWithClickEvents: <explanation>
-                <div
+                <button
                   // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
                   key={id + curDate + idx}
                   className="flex items-center justify-center relative"
+                  type="button"
                   onClick={() =>
                     isActiveClick &&
                     !isInRange &&
@@ -317,7 +317,7 @@ function SelectDateCalendar({ selectedDateNum, selectedDate, handleSelectDate }:
                   >
                     {curDate}
                   </p>
-                </div>
+                </button>
               );
             })
           )}

--- a/apps/mobile/components/select-date/SelectDateCalendar.tsx
+++ b/apps/mobile/components/select-date/SelectDateCalendar.tsx
@@ -2,13 +2,13 @@
 
 import { MobileIconArrowLeftGray, MobileIconArrowRightGray } from "@setaday/icon";
 import { useState } from "react";
-import { DAY, MAX_DATE, MONTH_NAMES } from "../../constants/selectDateConst";
+import { DAY, MAX_DATE, MONTH_NAMES, TODAYS_DATE, TODAYS_MONTH, TODAYS_YEAR } from "../../constants/selectDateConst";
 import type { ClickDateProps, SelctDateCalendarProps, SelectedDateType } from "../../type/selectedDateType";
 import { getCalendarDate } from "../../utils/getCalendarDate";
 
 function SelectDateCalendar({ selectedDateNum, selectedDate, handleSelectDate }: SelctDateCalendarProps) {
-  const [year, setYear] = useState(new Date().getFullYear());
-  const [month, setMonth] = useState(new Date().getMonth() + 1);
+  const [year, setYear] = useState(TODAYS_YEAR);
+  const [month, setMonth] = useState(TODAYS_MONTH);
 
   const ALL_DATE = getCalendarDate({ year, month });
 
@@ -248,9 +248,13 @@ function SelectDateCalendar({ selectedDateNum, selectedDate, handleSelectDate }:
         </header>
 
         <div className="grid grid-cols-7 grid-rows-5 gap-y-[1.8rem]">
-          {ALL_DATE.map(({ id, date, color }) =>
+          {ALL_DATE.map(({ id, date }) =>
             date.map((curDate) => {
-              const isActiveClick = id === "currentDate";
+              const isActiveDate =
+                year >= TODAYS_YEAR && (month > TODAYS_MONTH || (month === TODAYS_MONTH && curDate >= TODAYS_DATE));
+
+              const isActiveClick = id === "currentDate" && isActiveDate;
+
               const idxOfStartDate = selectedDate.findIndex(
                 ({ startDate, startMonth, startYear }) =>
                   startDate === curDate && startMonth === month && startYear === year
@@ -265,6 +269,8 @@ function SelectDateCalendar({ selectedDateNum, selectedDate, handleSelectDate }:
               const isEndDate = idxOfEndDate > -1;
 
               const isClickedNum = isActiveClick && (isStartDate || isEndDate);
+
+              const dateColor = isClickedNum ? "text-white" : isActiveClick ? "text-gray-6" : "text-gray-4";
 
               const isInRange =
                 isActiveClick &&
@@ -309,9 +315,9 @@ function SelectDateCalendar({ selectedDateNum, selectedDate, handleSelectDate }:
                   )}
 
                   <p
-                    className={`flex items-center justify-center w-[3.6rem] h-[3.6rem] z-10 rounded-full font-body5_m_14  ${
-                      isClickedNum ? "text-white" : color
-                    } ${isClickedNum && "bg-key"} `}
+                    className={`flex items-center justify-center w-[3.6rem] h-[3.6rem] z-10 rounded-full font-body5_m_14  ${dateColor} ${
+                      isClickedNum && "bg-key"
+                    } `}
                   >
                     {curDate}
                   </p>

--- a/apps/mobile/components/select-date/SelectDateCalendar.tsx
+++ b/apps/mobile/components/select-date/SelectDateCalendar.tsx
@@ -2,7 +2,7 @@
 
 import { MobileIconArrowLeftGray, MobileIconArrowRightGray } from "@setaday/icon";
 import { useState } from "react";
-import { DAY, MAX_DATE, MONTH_NAMES, TODAYS_DATE, TODAYS_MONTH, TODAYS_YEAR } from "../../constants/selectDateConst";
+import { DAY, MAX_DATE, MONTH_NAMES, TODAYS_MONTH, TODAYS_YEAR } from "../../constants/selectDateConst";
 import type { ClickDateProps, SelctDateCalendarProps, SelectedDateType } from "../../type/selectedDateType";
 import { getCalendarDate } from "../../utils/getCalendarDate";
 
@@ -248,12 +248,9 @@ function SelectDateCalendar({ selectedDateNum, selectedDate, handleSelectDate }:
         </header>
 
         <div className="grid grid-cols-7 grid-rows-5 gap-y-[1.8rem]">
-          {ALL_DATE.map(({ id, date }) =>
-            date.map((curDate) => {
-              const isActiveDate =
-                year >= TODAYS_YEAR && (month > TODAYS_MONTH || (month === TODAYS_MONTH && curDate >= TODAYS_DATE));
-
-              const isActiveClick = id === "currentDate" && isActiveDate;
+          {ALL_DATE.map(({ id, date, color }) =>
+            date.map((curDate, idx) => {
+              const isActiveClick = id === "validDate";
 
               const idxOfStartDate = selectedDate.findIndex(
                 ({ startDate, startMonth, startYear }) =>
@@ -269,8 +266,6 @@ function SelectDateCalendar({ selectedDateNum, selectedDate, handleSelectDate }:
               const isEndDate = idxOfEndDate > -1;
 
               const isClickedNum = isActiveClick && (isStartDate || isEndDate);
-
-              const dateColor = isClickedNum ? "text-white" : isActiveClick ? "text-gray-6" : "text-gray-4";
 
               const isInRange =
                 isActiveClick &&
@@ -294,7 +289,8 @@ function SelectDateCalendar({ selectedDateNum, selectedDate, handleSelectDate }:
               return (
                 // biome-ignore lint/a11y/useKeyWithClickEvents: <explanation>
                 <div
-                  key={id + curDate}
+                  // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+                  key={id + curDate + idx}
                   className="flex items-center justify-center relative"
                   onClick={() =>
                     isActiveClick &&
@@ -315,9 +311,9 @@ function SelectDateCalendar({ selectedDateNum, selectedDate, handleSelectDate }:
                   )}
 
                   <p
-                    className={`flex items-center justify-center w-[3.6rem] h-[3.6rem] z-10 rounded-full font-body5_m_14  ${dateColor} ${
-                      isClickedNum && "bg-key"
-                    } `}
+                    className={`flex items-center justify-center w-[3.6rem] h-[3.6rem] z-10 rounded-full font-body5_m_14  ${
+                      isClickedNum ? "text-white" : color
+                    } ${isClickedNum && "bg-key"} `}
                   >
                     {curDate}
                   </p>

--- a/apps/mobile/constants/selectDateConst.ts
+++ b/apps/mobile/constants/selectDateConst.ts
@@ -18,3 +18,7 @@ export const MONTH_NAMES = [
   "November",
   "December",
 ];
+
+export const TODAYS_YEAR = new Date().getFullYear();
+export const TODAYS_MONTH = new Date().getMonth() + 1;
+export const TODAYS_DATE = new Date().getDate();

--- a/apps/mobile/utils/getCalendarDate.ts
+++ b/apps/mobile/utils/getCalendarDate.ts
@@ -22,13 +22,11 @@ export const getCalendarDate = ({
     {
       id: "lastDate",
       date: LAST_DATE,
-      color: "text-gray-4",
     },
     { id: "currentDate", date: DATE, color: "text-gray-6" },
     {
       id: "nextDate",
       date: NEXT_DATE,
-      color: "text-gray-4",
     },
   ];
 

--- a/apps/mobile/utils/getCalendarDate.ts
+++ b/apps/mobile/utils/getCalendarDate.ts
@@ -1,3 +1,6 @@
+import { TODAYS_DATE, TODAYS_MONTH } from "../constants/selectDateConst";
+import { TODAYS_YEAR } from "./../constants/selectDateConst";
+
 export const getCalendarDate = ({
   year,
   month,
@@ -14,19 +17,64 @@ export const getCalendarDate = ({
   // 지난 달 마지막 날짜
   const lastEndDate = new Date(year, month - 1, 0).getDate();
 
+  const isCurrentMonth = year === TODAYS_YEAR && month === TODAYS_MONTH;
+  const isPastYear = year < TODAYS_YEAR;
+  const isFutureYear = year > TODAYS_YEAR;
+  const isPastMonthsOfThisYear = year === TODAYS_YEAR && month < TODAYS_MONTH;
+  const isFutureMonthsOfThisYear = year === TODAYS_YEAR && month > TODAYS_MONTH;
+
   const DATE = Array.from({ length: endDate }, (_, idx) => idx + 1);
-  const LAST_DATE = Array.from({ length: startDay }, (_, idx) => lastEndDate - (startDay - idx - 1));
-  const NEXT_DATE = Array.from({ length: nextStartDay === 0 ? 0 : 7 - nextStartDay }, (_, idx) => idx + 1);
+
+  // 선택 제한 날짜
+  const INVALID_DATE = DATE.filter((date) => {
+    // 이번 년도, 이번 달의 경우 오늘의 날짜보다 작은 날짜는 선택 불가
+    if (isCurrentMonth) {
+      return date < TODAYS_DATE;
+    }
+
+    // 지난 년도 || 이번 년도의 지난 달의 경우, 모든 날짜 선택 불가
+    if (isPastYear || isPastMonthsOfThisYear) {
+      return date;
+    }
+  });
+
+  // 선택 가능 날짜
+  const VALID_DATE = DATE.filter((date) => {
+    // 이번 년도, 이번 달의 경우 오늘의 날짜보다 크거나 같은 날짜 선택 가능
+    if (isCurrentMonth) {
+      return date >= TODAYS_DATE;
+    }
+
+    // 다음 년도 || 이번 년도의 이후 달의 경우, 모든 날짜 선택 가능
+    if (isFutureYear || isFutureMonthsOfThisYear) {
+      return date;
+    }
+  });
+
+  // 오늘이 속한 달에 표시해야 할 지난 달의 날짜
+  const LAST_MONTH_DATE = Array.from({ length: startDay }, (_, idx) => lastEndDate - (startDay - idx - 1));
+
+  // 오늘 이전의 모든 날짜 (올해 이하인 경우, 지난 달 날짜와 선택 불가 날짜를 포함 / 내년 이상인 경우 지난 달 날짜만 포함)
+  const LAST_DATE = year <= TODAYS_YEAR ? [...LAST_MONTH_DATE, ...INVALID_DATE] : LAST_MONTH_DATE;
+
+  // 오늘이 속한 달에 표시해야 할 다음 달의 날짜
+  const NEXT_MONTH_DATE = Array.from({ length: nextStartDay === 0 ? 0 : 7 - nextStartDay }, (_, idx) => idx + 1);
 
   const ALL_DATE = [
     {
       id: "lastDate",
       date: LAST_DATE,
+      color: "text-gray-4",
     },
-    { id: "currentDate", date: DATE, color: "text-gray-6" },
+    {
+      id: "validDate",
+      date: VALID_DATE,
+      color: "text-gray-6",
+    },
     {
       id: "nextDate",
-      date: NEXT_DATE,
+      date: NEXT_MONTH_DATE,
+      color: "text-gray-4",
     },
   ];
 


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #123 

## ✅ 작업 내용

- [x] 오늘 날짜 기준, 지난 날짜는 캘린더에서 선택 제한

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/58646f56-711e-4c03-9cbd-ec580284d902

## 📌 이슈 사항
처음에는 캘린더 날짜 데이터를 불러오는 함수를 그대로 유지한 상태에서, 데이터를 렌더링할 때 이전 날짜를 계산하고 선택을 제한하는 방식으로 구현했어요. 그런데 return 문 내부에서 불필요한 연산이 증가하는 것이 바람직하지 않다고 판단하여, 날짜 데이터를 반환하는 함수 자체에서 필요한 연산을 수행하도록 수정했어요.

`선택이 제한되는 날짜`는 아래와 같아요. (오늘의 날짜 기준)
1. 작년의 모든 날짜
2. 올해지만 지난 모든 달의 날짜
3. 올해, 이번 달이지만 오늘 이전의 날짜
4. 이번 달 달력에서 보조적으로 표시되는 지난달의 날짜
5. 이번 달 달력에서 보조적으로 표시되는 다음달의 날짜


이전에는 4번과 5번을 제외한 모든 날짜를 선택 가능하도록 구현했지만, 불필요한 연산을 줄이기 위해 처음부터 연산된 결과를 상수로 반환해요.
우선, 선택 불가능한 모든 날짜를 `LAST_DATE` 상수에 저장하고, 선택 가능한 날짜는 `VALID_DATE`로 분리했어요.
또한, 이번 달 달력에 표시되는 지난 달의 날짜(4번 조건) 를 `LAST_MONTH_DATE`로 별도로 저장하고,
올해에 속하지만 선택할 수 없는 달의 날짜(2번 조건) 를 `INVALIDATE_DATE`로 정의했어요.

따라서 날짜 데이터를 반환할 때,
- **올해 이하**인 경우 `LAST_DATE`에 `LAST_MONTH_DATE`와 `INVALIDATE_DATE`를 포함하여 반환
- **내년 이상**인 경우 `LAST_DATE`에 `LAST_MONTH_DATE`만 포함하여 반환
하는 방식으로 구현하여, 보다 명확하고 일관된 방식으로 날짜 선택을 제한해요.
